### PR TITLE
Fix 3d scatter plot axis switching issues

### DIFF
--- a/visualisation_components.py
+++ b/visualisation_components.py
@@ -415,9 +415,9 @@ class ScatterPlot3D(QVBoxLayout, PlotLayout):
         """
         print("WARNING: trying to plot point on normalized axis while non normalized data is present!")
         print("\tSWITCHING TO DISPLAYING NON NORMALIZED DATA...")
-        self._axis_var_x = self._axis_var_x.rstrip("_norm") + "_snv"
-        self._axis_var_y = self._axis_var_y.rstrip("_norm") + "_snv"
-        self._axis_var_z = self._axis_var_z.rstrip("_norm") + "_snv"
+        self._axis_var_x = self._axis_var_x.replace("_norm", "_snv")
+        self._axis_var_y = self._axis_var_y.replace("_norm", "_snv")
+        self._axis_var_z = self._axis_var_z.replace("_norm", "_snv")
         self._axXSelection.setCurrentText(self._axis_var_x)
         self._axYSelection.setCurrentText(self._axis_var_y)
         self._axZSelection.setCurrentText(self._axis_var_z)

--- a/visualisation_components.py
+++ b/visualisation_components.py
@@ -393,14 +393,17 @@ class ScatterPlot3D(QVBoxLayout, PlotLayout):
 
     def _ax_x_changed(self, name) -> None:
         self._axis_var_x = name
+        self._graph.axisX().setTitle(self._axis_var_x)
         self.plot(axis_changed=True)
 
     def _ax_y_changed(self, name) -> None:
         self._axis_var_y = name
+        self._graph.axisY().setTitle(self._axis_var_y)
         self.plot(axis_changed=True)
 
     def _ax_z_changed(self, name) -> None:
         self._axis_var_z = name
+        self._graph.axisZ().setTitle(self._axis_var_z)
         self.plot(axis_changed=True)
 
     def clear(self) -> None:

--- a/visualisation_components.py
+++ b/visualisation_components.py
@@ -406,6 +406,24 @@ class ScatterPlot3D(QVBoxLayout, PlotLayout):
         self._graph.axisZ().setTitle(self._axis_var_z)
         self.plot(axis_changed=True)
 
+    def _switch_axes_to_snv(self) -> None:
+        """
+        Switches normalized axes to SNV axes since it's assumed that
+        SNV column is always present in data. Normalized columns not
+        present when taking readings without first taking a calibration
+        measurement.
+        """
+        print("WARNING: trying to plot point on normalized axis while non normalized data is present!")
+        print("\tSWITCHING TO DISPLAYING NON NORMALIZED DATA...")
+        self._axis_var_x = self._axis_var_x.rstrip("_norm") + "_snv"
+        self._axis_var_y = self._axis_var_y.rstrip("_norm") + "_snv"
+        self._axis_var_z = self._axis_var_z.rstrip("_norm") + "_snv"
+        self._axXSelection.setCurrentText(self._axis_var_x)
+        self._axYSelection.setCurrentText(self._axis_var_y)
+        self._axZSelection.setCurrentText(self._axis_var_z)
+
+        self.plot(axis_changed=True)
+
     def clear(self) -> None:
         for material in self.unique_series:
             for id in self.unique_series[material]:
@@ -478,23 +496,7 @@ class ScatterPlot3D(QVBoxLayout, PlotLayout):
 
                             proxy.resetArray(dataArray)
                         else:
-                            for data in self.unique_series[material][id]["data"]:
-                                if (
-                                    data[index_x] is None
-                                    or data[index_y] is None
-                                    or data[index_z] is None
-                                ):
-                                    print(
-                                        "WARNING: trying to plot point on normalized axis while non normalized data is present!"
-                                    )
-                                    print("\tSWITCHING TO DISPLAYING NON NORMALIZED DATA...")
-                                    self._axis_var_x = self._axis_var_x.rstrip("_norm") + "_snv"
-                                    self._axis_var_y = self._axis_var_y.rstrip("_norm") + "_snv"
-                                    self._axis_var_z = self._axis_var_z.rstrip("_norm") + "_snv"
-                                    self._axXSelection.setCurrentText(self._axis_var_x)
-                                    self._axYSelection.setCurrentText(self._axis_var_y)
-                                    self._axZSelection.setCurrentText(self._axis_var_z)
-                            self.plot(axis_changed=True)
+                            self._switch_axes_to_snv()
                             return
 
                         if series not in self._graph.seriesList():


### PR DESCRIPTION
The first commit fixes #30, and the others address a bug with plotting non-normalized data.

To reproduce the second bug:
1. `python psplot.py` without anything hooked up, so it's using dummy data
2. Check box to disable bar chart (so it's not also generating errors)
3. Click `Take measurement`, and click `yes` on warning about there not being a calibration.
4. Click "Default axes"
5. Terminal fills with output about switching axes and KeyErrors. Doesn't switch axes properly and the plot stops updating

This makes it switch to _snv axes properly and avoids the plot getting stuck